### PR TITLE
Update to use node16 runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: 'Specify a specific format. Available options are "gcc" or "tty"'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
The `node12` runner has been deprecated ([see GitHub blog post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)). Whenever this action is used, it emits an annotation, warning about this deprecation.